### PR TITLE
alter schema on int types

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,7 @@
   ],
   "cSpell.words": [
     "agol",
+    "cadastre",
     "cloudb",
     "colorama",
     "conda",
@@ -36,6 +37,7 @@
     "psycopg",
     "pyodbc",
     "rolname",
+    "sgid",
     "stas",
     "strftime"
   ]

--- a/src/cloudb/main.py
+++ b/src/cloudb/main.py
@@ -13,7 +13,7 @@ Usage:
   cloudb import [--missing --dry-run --verbosity=<level> --skip-if-exists]
   cloudb trim [--dry-run --verbosity=<level>]
   cloudb update [--table=<tables>... --dry-run --verbosity=<level> --from-change-detection]
-  cloudb update schema [--table=<tables>... --dry-run --verbosity=<level>]
+  cloudb update-schema [--table=<tables>... --dry-run --verbosity=<level>]
 '''
 
 import sys
@@ -637,26 +637,6 @@ def main():
         sys.exit()
 
     if args['update']:
-        if args['schema']:
-            tables = args['--table']
-
-            if len(tables) == 0:
-                schema.update_schemas(_get_table_meta(), args['--dry-run'])
-            else:
-                agol_meta_map = _get_table_meta()
-
-                for sgid_table in tables:
-                    schema_name, table_name = sgid_table.lower().split('.')
-                    pg_table = f'{schema_name}.{agol_meta_map[schema_name][table_name]["title"]}'
-
-                    schema.update_schema_for(sgid_table, pg_table, args['--dry-run'])
-
-            LOG.info(
-                f'{Fore.GREEN}completed{Fore.RESET} in {Fore.CYAN}{utils.format_time(perf_counter() - start_seconds)}{Fore.RESET}'
-            )
-
-            sys.exit()
-
         tables = args['--table']
 
         if args['--from-change-detection']:
@@ -665,6 +645,26 @@ def main():
         update(tables, args['--dry-run'])
 
         LOG.info(f'{Fore.GREEN}completed{Fore.RESET} in {Fore.CYAN}{utils.format_time(perf_counter() - start_seconds)}{Fore.RESET}')
+
+        sys.exit()
+
+    if args['update-schema']:
+        tables = args['--table']
+
+        if len(tables) == 0:
+            schema.update_schemas(_get_table_meta(), args['--dry-run'])
+        else:
+            agol_meta_map = _get_table_meta()
+
+            for sgid_table in tables:
+                schema_name, table_name = sgid_table.lower().split('.')
+                pg_table = f'{schema_name}.{agol_meta_map[schema_name][table_name]["title"]}'
+
+                schema.update_schema_for(sgid_table, pg_table, args['--dry-run'])
+
+        LOG.info(
+            f'{Fore.GREEN}completed{Fore.RESET} in {Fore.CYAN}{utils.format_time(perf_counter() - start_seconds)}{Fore.RESET}'
+        )
 
         sys.exit()
 

--- a/src/cloudb/schema.py
+++ b/src/cloudb/schema.py
@@ -67,7 +67,11 @@ WHERE
             for column, data_type in result:
                 statements.append(f'ALTER COLUMN {column} TYPE {data_type} USING {column}::{data_type}')
 
-    import pdb; pdb.set_trace()
+    if len(statements) < 1:
+        LOG.verbose(f'skipping {Fore.RED}{pg_table}{Fore.RESET}')
+
+        return
+
     with psycopg2.connect(**config.DBO_CONNECTION) as conn:
         with conn.cursor() as cursor:
             sql = f'ALTER TABLE {pg_table} {", ".join(statements)};'

--- a/src/cloudb/schema.py
+++ b/src/cloudb/schema.py
@@ -5,7 +5,9 @@ schema.py
 A module that modifies schemas
 '''
 
+from colorama import Back, Fore
 import psycopg2
+import pyodbc
 from . import config, LOG
 
 
@@ -43,3 +45,85 @@ def create_schemas(schemas):
             cursor.execute(';'.join(sql))
 
         conn.commit()
+
+
+def update_schema_for(sql_table, pg_table, dry_run=False):
+    statements = []
+    with pyodbc.connect(config.get_source_connection()[6:]) as conn:
+        sql = """SELECT
+    LOWER(column_name) as column_name, data_type
+FROM
+    INFORMATION_SCHEMA.COLUMNS
+WHERE
+    LOWER(table_name) = ?
+    AND LOWER(table_schema) = ?
+    AND data_type in ('smallint', 'int', 'bigint')
+    AND column_name not in ('OBJECTID', 'OBJECTID_1');"""
+
+        with conn.cursor() as cursor:
+            schema_name, table_name = sql_table.split('.')
+            result = cursor.execute(sql, table_name, schema_name)
+
+            for column, data_type in result:
+                statements.append(f'ALTER COLUMN {column} TYPE {data_type} USING {column}::{data_type}')
+
+    import pdb; pdb.set_trace()
+    with psycopg2.connect(**config.DBO_CONNECTION) as conn:
+        with conn.cursor() as cursor:
+            sql = f'ALTER TABLE {pg_table} {", ".join(statements)};'
+            LOG.verbose(f'updating schema for {Fore.CYAN}{pg_table}{Fore.RESET} with {Fore.MAGENTA}{sql}{Fore.RESET}')
+
+            if not dry_run:
+                result = cursor.execute(sql)
+                LOG.verbose(f'result: {Fore.GREEN}{result}{Fore.RESET}')
+
+        if not dry_run:
+            conn.commit()
+
+def update_schemas(agol_meta_map, dry_run=False):
+    alter_statements = {}
+
+    with pyodbc.connect(config.get_source_connection()[6:]) as conn:
+        sql = """SELECT
+    LOWER(table_schema) as table_schema,
+    LOWER(table_name) as table_name,
+    lower(column_name) as column_name,
+    data_type
+FROM
+    INFORMATION_SCHEMA.COLUMNS c
+INNER JOIN meta.AGOLITEMS a ON
+    LOWER(a.tablename) = concat('sgid.', LOWER(table_schema), '.', LOWER(table_name))
+WHERE
+    c.data_type in ('smallint',
+    'int',
+    'bigint')
+    AND column_name not in ('OBJECTID', 'OBJECTID_1')
+    AND c.TABLE_SCHEMA not in ('sde',
+    'meta')
+ORDER BY
+    c.table_name;"""
+
+        with conn.cursor() as cursor:
+            result = cursor.execute(sql)
+
+            for schema_name, table_name, column, data_type in result:
+                pg_table = agol_meta_map[schema_name][table_name]['title']
+                pg_table = f'{schema_name}.{pg_table}'
+
+                alter_statements.setdefault(
+                    pg_table, []
+                ).append(f'ALTER COLUMN {column} TYPE {data_type} USING {column}::{data_type}')
+
+    with psycopg2.connect(**config.DBO_CONNECTION) as conn:
+        with conn.cursor() as cursor:
+            for table, alter_column_statements in alter_statements.items():
+                sql = f'ALTER TABLE {table} {", ".join(alter_column_statements)};'
+
+                LOG.verbose(f'updating schema for {Fore.CYAN}{table}{Fore.RESET} with {Fore.MAGENTA}{sql}{Fore.RESET}')
+
+                if not dry_run:
+                    result = cursor.execute(sql)
+                    LOG.verbose(f'result: {Fore.GREEN}{result}{Fore.RESET}')
+
+            if not dry_run:
+                conn.commit()


### PR DESCRIPTION
this adds two new methods on the update schema command to update a table or the entire database.

It queries the sql server for the problematic types and alters the columns in postgres.

I've run this over the open sgid without issue but i have not run it in the _replace_data path.